### PR TITLE
go-release permissions: write-all

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   goreleaser:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
closes #21 