### PR TITLE
fix: chains.yaml to always use `BUILD_TAGS=muslc`

### DIFF
--- a/simapp/.gitignore
+++ b/simapp/.gitignore
@@ -1,0 +1,1 @@
+configs/logs.json

--- a/simapp/chains.yaml
+++ b/simapp/chains.yaml
@@ -8,4 +8,4 @@
     - /go/bin/wasmd
   build-env:
     - LEDGER_ENABLED=false
-    - BUILD_TAGS=muslc //spawntag:wasm
+    - BUILD_TAGS=muslc


### PR DESCRIPTION
This does not need to be removed since it is required by the wasmlc as well. No downside to having

breaks local-ic if not in when using wasmlc but no wasm.