### PR TITLE
fix: go mod module namespace

### DIFF
--- a/cmd/spawn/local-interchain.go
+++ b/cmd/spawn/local-interchain.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"gitub.com/rollchains/spawn/spawn"
+	"github.com/rollchains/spawn/spawn"
 )
 
 const (

--- a/cmd/spawn/main.go
+++ b/cmd/spawn/main.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/lmittmann/tint"
 	"github.com/mattn/go-isatty"
+	"github.com/rollchains/spawn/plugins"
 	"github.com/spf13/cobra"
-	"gitub.com/rollchains/spawn/plugins"
 )
 
 // Set in the makefile ld_flags on compile

--- a/cmd/spawn/module.go
+++ b/cmd/spawn/module.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/rollchains/simapp"
+	"github.com/rollchains/spawn/spawn"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"gitub.com/rollchains/spawn/spawn"
 
 	textcases "golang.org/x/text/cases"
 	lang "golang.org/x/text/language"

--- a/cmd/spawn/new_chain.go
+++ b/cmd/spawn/new_chain.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"gitub.com/rollchains/spawn/spawn"
+	"github.com/rollchains/spawn/spawn"
 )
 
 var (

--- a/cmd/spawn/proto.go
+++ b/cmd/spawn/proto.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/rollchains/spawn/spawn"
 	"github.com/spf13/cobra"
-	"gitub.com/rollchains/spawn/spawn"
 )
 
 func ProtoServiceGenerate() *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitub.com/rollchains/spawn
+module github.com/rollchains/spawn
 
 go 1.21.0
 

--- a/plugins/example/example-plugin.go
+++ b/plugins/example/example-plugin.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path"
 
+	plugins "github.com/rollchains/spawn/plugins"
 	"github.com/spf13/cobra"
-	plugins "gitub.com/rollchains/spawn/plugins"
 )
 
 // Make the plugin public


### PR DESCRIPTION
only applies to importing spawn from an outside repo (plugins)