### PR TITLE
fix(module): proto namespace generation

### DIFF
--- a/.github/workflows/spawn-e2e.yaml
+++ b/.github/workflows/spawn-e2e.yaml
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
       id: Normal Staking
-      spawn-create-cmd: ./spawn new mychain --bypass-prompt --bech32=roll --bin=appd --no-git --org=rollchains --denom=uroll --debug --disable=ics
+      spawn-create-cmd: ./spawn new mychain --bypass-prompt --bech32=roll --bin=appd --no-git --org=rollchains-org --denom=uroll --debug --disable=ics
       start-chain-cmd: HOME_DIR="~/.simapp" CHAIN_ID="local-1" BLOCK_TIME="2000ms" CLEAN=true sh scripts/test_node.sh &
 
   normal-ics:
@@ -59,5 +59,5 @@ jobs:
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
       id: ICS
-      spawn-create-cmd: ./spawn new mychain --bin=appd --bypass-prompt --bech32=roll --no-git --org=rollchains --denom=uroll --debug
+      spawn-create-cmd: ./spawn new mychain --bin=appd --bypass-prompt --bech32=roll --no-git --org=rollchains-org --denom=uroll --debug
       start-chain-cmd: HOME_DIR="~/.icsnetwork" CHAIN_ID="local-2" CLEAN=true BLOCK_TIME="500ms" sh scripts/test_ics_node.sh &

--- a/cmd/spawn/module.go
+++ b/cmd/spawn/module.go
@@ -181,7 +181,6 @@ func SetupModuleProtoBase(logger *slog.Logger, extName string, feats *features) 
 		}
 
 		fc.ReplaceAll("github.com/rollchains/spawn/simapp", goModName)
-		fc.ReplaceAll("strangelove_ventures.simapp", protoNamespace)
 
 		// replace example -> the new x/ name
 		fc.ReplaceAll(moduleName, extName)
@@ -378,5 +377,6 @@ func appendNewImportsToSource(filePath string, oldSource, newImports []string) [
 // i.e. github.com/rollchains/myproject -> rollchains.myproject
 func convertGoModuleNameToProtoNamespace(moduleName string) string {
 	text := strings.Replace(moduleName, "github.com/", "", 1)
+
 	return strings.Replace(text, "/", ".", -1)
 }

--- a/simapp/proto/example/module/v1/module.proto
+++ b/simapp/proto/example/module/v1/module.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package strangelove_ventures.simapp.example.module.v1;
+package example.module.v1;
 
 import "cosmos/app/v1alpha1/module.proto";
 


### PR DESCRIPTION
closes #138

It did not like -'s, but tbh we don't even need it for the module v1 proto namespace. best part is no part