### PR TITLE
fix: block times too fast for local testnet

### DIFF
--- a/simapp/contrib/devtools/README.md
+++ b/simapp/contrib/devtools/README.md
@@ -3,4 +3,4 @@
 Thanks to the entire Cosmos SDK team and the contributors who put their efforts into making simulation testing
 easier to implement. 🤗
 
-https://github.com/cosmos/cosmos-sdk/blob/master/contrib/devtools/Makefile
+https://github.com/cosmos/cosmos-sdk/blob/v0.50.7/contrib/devtools/Makefile


### PR DESCRIPTION
## Issues
- Go Relayer could not keep up w/ 500ms or 1s blocks (always out of sync)
- Too fast for the hub gov proposal to go through with ICS (from 3s -> 10s)