### PR TITLE
test(e2e): module generation + fix BUF cache permission issue

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -17,6 +17,10 @@ on:
         type: string
         required: true
         description: 'The command which runs the chain via the shell'
+      spawn-extra-cmd:
+        type: string
+        required: false
+        description: 'Extra command to run after the chain is created'
 
 env:
   GO_VERSION: 1.22.3
@@ -68,7 +72,16 @@ jobs:
 
       # === Chain Creation & Validation ===
       - name: Spawn Gen - '${{inputs.id}}'
-        run: ${{ inputs.spawn-create-cmd }}
+        run: |
+          git config --global --add url."git@github.com:".insteadOf "https://github.com/"
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+          ${{ inputs.spawn-create-cmd }}
+          pwd
+
+      - name: Spawn Extra Generation
+        if : ${{ inputs.spawn-extra-cmd }}
+        run: ${{ inputs.spawn-extra-cmd }}
 
       - name: Build and Run '${{inputs.id}}'
         run: |

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -66,9 +66,10 @@ jobs:
         uses: actions/download-artifact@master
         with:
           name: spawn
+          path: /home/runner/go/bin
 
-      - name: Spawn Permission
-        run: chmod +x ./spawn && ls -l
+      - name: Spawn Permission # put into path
+        run: chmod +x /home/runner/go/bin/spawn && ls -l
 
       # === Chain Creation & Validation ===
       - name: Spawn Gen - '${{inputs.id}}'
@@ -88,6 +89,8 @@ jobs:
           cd mychain
           ${{ inputs.start-chain-cmd }}
 
+      # Runs the unit test after the chain is started in the background
+      # This way the work is parallelized
       - name: Unit Test - '${{inputs.id}}'
         run: |
           cd mychain

--- a/.github/workflows/spawn-e2e.yaml
+++ b/.github/workflows/spawn-e2e.yaml
@@ -69,3 +69,12 @@ jobs:
       id: ICS - Cosmos Hub
       spawn-create-cmd: ./spawn new mychain --consensus=ics --bin=appd --bypass-prompt --bech32=roll --no-git --org=rollchains-org --denom=uroll --debug --log-level=debug
       start-chain-cmd: HOME_DIR="~/.icsnetwork" CHAIN_ID="localchain-2" CLEAN=true BLOCK_TIME="2000ms" sh scripts/test_ics_node.sh &
+
+  ics-with-user-modules:
+    needs: build-spawn
+    uses: ./.github/workflows/reusable-e2e.yaml
+    with:
+      id: ICS - Module Plugins
+      spawn-create-cmd: spawn new mychain --consensus=ics --bin=appd --bypass-prompt --bech32=roll --disabled=explorer --org=rollchains-org --denom=uroll --debug --log-level=debug
+      spawn-extra-cmd: cd mychain && spawn module new aaaaaa && make proto-gen
+      start-chain-cmd: HOME_DIR="~/.icsnetwork" CHAIN_ID="localchain-2" CLEAN=true BLOCK_TIME="2000ms" sh scripts/test_ics_node.sh &

--- a/.github/workflows/spawn-e2e.yaml
+++ b/.github/workflows/spawn-e2e.yaml
@@ -74,7 +74,16 @@ jobs:
     needs: build-spawn
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
-      id: ICS - Module Plugins
+      id: ICS - Module
       spawn-create-cmd: spawn new mychain --consensus=ics --bin=appd --bypass-prompt --bech32=roll --disabled=explorer --org=rollchains-org --denom=uroll --debug --log-level=debug
       spawn-extra-cmd: cd mychain && spawn module new aaaaaa && make proto-gen
       start-chain-cmd: HOME_DIR="~/.icsnetwork" CHAIN_ID="localchain-2" CLEAN=true BLOCK_TIME="2000ms" sh scripts/test_ics_node.sh &
+
+  poa-with-ibc-module:
+    needs: build-spawn
+    uses: ./.github/workflows/reusable-e2e.yaml
+    with:
+      id: POA - IBC Module
+      spawn-create-cmd: spawn new mychain --consensus=poa --bin=appd --bypass-prompt --bech32=roll --disabled=explorer --org=rollchains-org --denom=upoa --debug --log-level=debug
+      spawn-extra-cmd: cd mychain && spawn module new aaaaaa --ibc-module && make proto-gen
+      start-chain-cmd: HOME_DIR="~/.simapp" CHAIN_ID="localchain-10" CLEAN=true BLOCK_TIME="2000ms" sh scripts/test_node.sh &

--- a/.github/workflows/spawn-e2e.yaml
+++ b/.github/workflows/spawn-e2e.yaml
@@ -76,5 +76,5 @@ jobs:
     with:
       id: ICS - Module Plugins
       spawn-create-cmd: spawn new mychain --consensus=ics --bin=appd --bypass-prompt --bech32=roll --disabled=explorer --org=rollchains-org --denom=uroll --debug --log-level=debug
-      spawn-extra-cmd: cd mychain && spawn module new aaaaaa && make proto-gen
+      spawn-extra-cmd: cd mychain && ../spawn module new aaaaaa && make proto-gen
       start-chain-cmd: HOME_DIR="~/.icsnetwork" CHAIN_ID="localchain-2" CLEAN=true BLOCK_TIME="2000ms" sh scripts/test_ics_node.sh &

--- a/.github/workflows/spawn-e2e.yaml
+++ b/.github/workflows/spawn-e2e.yaml
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
       id: Proof of Stake
-      spawn-create-cmd: ./spawn new mychain --consensus=proof-of-stake --bypass-prompt --bech32=prefix --bin=appd --no-git --org=rollchains-org --denom=uroll --debug --log-level=debug
+      spawn-create-cmd: spawn new mychain --consensus=proof-of-stake --bypass-prompt --bech32=prefix --bin=appd --no-git --org=rollchains-org --denom=uroll --debug --log-level=debug
       start-chain-cmd: HOME_DIR="~/.simapp" CHAIN_ID="localchain-1" BLOCK_TIME="2000ms" CLEAN=true sh scripts/test_node.sh &
 
   proof-of-authority:
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
       id: Proof of Authority
-      spawn-create-cmd: ./spawn new mychain --consensus=proof-of-authority --bypass-prompt --bech32=cosmos --bin=appd --no-git --org=rollchains-org --denom=uroll --debug --log-level=debug
+      spawn-create-cmd: spawn new mychain --consensus=proof-of-authority --bypass-prompt --bech32=cosmos --bin=appd --no-git --org=rollchains-org --denom=uroll --debug --log-level=debug
       start-chain-cmd: HOME_DIR="~/.simapp" CHAIN_ID="localchain-1" BLOCK_TIME="2000ms" CLEAN=true sh scripts/test_node.sh &
 
   normal-ics:
@@ -67,7 +67,7 @@ jobs:
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
       id: ICS - Cosmos Hub
-      spawn-create-cmd: ./spawn new mychain --consensus=ics --bin=appd --bypass-prompt --bech32=roll --no-git --org=rollchains-org --denom=uroll --debug --log-level=debug
+      spawn-create-cmd: spawn new mychain --consensus=ics --bin=appd --bypass-prompt --bech32=roll --no-git --org=rollchains-org --denom=uroll --debug --log-level=debug
       start-chain-cmd: HOME_DIR="~/.icsnetwork" CHAIN_ID="localchain-2" CLEAN=true BLOCK_TIME="2000ms" sh scripts/test_ics_node.sh &
 
   ics-with-user-modules:
@@ -76,5 +76,5 @@ jobs:
     with:
       id: ICS - Module Plugins
       spawn-create-cmd: spawn new mychain --consensus=ics --bin=appd --bypass-prompt --bech32=roll --disabled=explorer --org=rollchains-org --denom=uroll --debug --log-level=debug
-      spawn-extra-cmd: cd mychain && ../spawn module new aaaaaa && make proto-gen
+      spawn-extra-cmd: cd mychain && spawn module new aaaaaa && make proto-gen
       start-chain-cmd: HOME_DIR="~/.icsnetwork" CHAIN_ID="localchain-2" CLEAN=true BLOCK_TIME="2000ms" sh scripts/test_ics_node.sh &

--- a/docs/versioned_docs/version-v0.50.x/02-build-your-application/01-nameservice.md
+++ b/docs/versioned_docs/version-v0.50.x/02-build-your-application/01-nameservice.md
@@ -55,14 +55,8 @@ spawn module new nameservice
 
 # proto-gen proto files to go
 #
-# If you get a /.cache permission error, run:
-# sudo chmod -R 777 $(pwd)/.cache
-# sudo chown -R $USER $(pwd)/.cache
-#
 # If you get a cannot find module error
 # go clean -modcache
-#
-
 make proto-gen
 ```
 

--- a/simapp/Makefile
+++ b/simapp/Makefile
@@ -193,7 +193,6 @@ CURRENT_GID := $(shell id -g)
 
 protoVer=0.13.2
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
-# $(CURDIR)/.cache:/.cache:rw is macOS specific due to buf saving to a read-only directory
 protoImage=$(DOCKER) run -e BUF_CACHE_DIR=/tmp/buf --rm -v $(CURDIR):/workspace:rw --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
 
 proto-all: proto-format proto-lint proto-gen format

--- a/simapp/Makefile
+++ b/simapp/Makefile
@@ -194,7 +194,7 @@ CURRENT_GID := $(shell id -g)
 protoVer=0.13.2
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 # $(CURDIR)/.cache:/.cache:rw is macOS specific due to buf saving to a read-only directory
-protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw --mount type=volume,source=tmp,target=/.cache --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
+protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw --mount type=volume,source=tmp,target=/.cache/buf/v2 --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
 
 proto-all: proto-format proto-lint proto-gen format
 

--- a/simapp/Makefile
+++ b/simapp/Makefile
@@ -194,7 +194,7 @@ CURRENT_GID := $(shell id -g)
 protoVer=0.13.2
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 # $(CURDIR)/.cache:/.cache:rw is macOS specific due to buf saving to a read-only directory
-protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw -v $(CURDIR)/.cache:/.cache:rw --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
+protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw -v $(CURDIR)/.cache/buf:/.cache/buf:rwx --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
 
 proto-all: proto-format proto-lint proto-gen format
 

--- a/simapp/Makefile
+++ b/simapp/Makefile
@@ -194,8 +194,7 @@ CURRENT_GID := $(shell id -g)
 protoVer=0.13.2
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 # $(CURDIR)/.cache:/.cache:rw is macOS specific due to buf saving to a read-only directory
-# TODO: maybe mount instead? ref cosmwasm container / https://docs.docker.com/engine/storage/bind-mounts/
-protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw -v $(CURDIR)/.cache/buf:/.cache/buf:rw --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
+protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw --mount type=volume,source=tmp,target=/.cache --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
 
 proto-all: proto-format proto-lint proto-gen format
 

--- a/simapp/Makefile
+++ b/simapp/Makefile
@@ -194,7 +194,8 @@ CURRENT_GID := $(shell id -g)
 protoVer=0.13.2
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 # $(CURDIR)/.cache:/.cache:rw is macOS specific due to buf saving to a read-only directory
-protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw -v $(CURDIR)/.cache/buf:/.cache/buf:rwx --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
+# TODO: maybe mount instead? ref cosmwasm container / https://docs.docker.com/engine/storage/bind-mounts/
+protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw -v $(CURDIR)/.cache/buf:/.cache/buf:rw --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
 
 proto-all: proto-format proto-lint proto-gen format
 

--- a/simapp/Makefile
+++ b/simapp/Makefile
@@ -194,7 +194,7 @@ CURRENT_GID := $(shell id -g)
 protoVer=0.13.2
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 # $(CURDIR)/.cache:/.cache:rw is macOS specific due to buf saving to a read-only directory
-protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw --mount type=volume,source=tmp,target=/.cache/buf/v2 --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
+protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw --mount type=volume,source=tmp,target=/.cache/buf/v2/module --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
 
 proto-all: proto-format proto-lint proto-gen format
 

--- a/simapp/Makefile
+++ b/simapp/Makefile
@@ -194,7 +194,7 @@ CURRENT_GID := $(shell id -g)
 protoVer=0.13.2
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 # $(CURDIR)/.cache:/.cache:rw is macOS specific due to buf saving to a read-only directory
-protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace:rw --mount type=volume,source=tmp,target=/.cache/buf/v2/module --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
+protoImage=$(DOCKER) run -e BUF_CACHE_DIR=/tmp/buf --rm -v $(CURDIR):/workspace:rw --user ${CURRENT_UID}:${CURRENT_GID} --workdir /workspace $(protoImageName)
 
 proto-all: proto-format proto-lint proto-gen format
 


### PR DESCRIPTION
## Summary

Recently the patch https://github.com/rollchains/spawn/pull/238 was pushed which I believe will fix module generation issues I was having before. I figured it was github runner issues, but may have been the Ubuntu 22.04 bug found and reported by other users (due to file system permissions). This re-attempts the module generation I started in https://github.com/rollchains/spawn/pull/172