### PR TITLE
feat: standalone chain

### DIFF
--- a/spawn/cfg.go
+++ b/spawn/cfg.go
@@ -344,6 +344,11 @@ func (cfg *NewChainConfig) SetupLocalInterchainJSON() {
 	if cfg.IsFeatureEnabled(InterchainSecurity) {
 		c.SetICSConsumerLink("localcosmos-1")
 	} else {
+		// Standalone testnet with no IBC connections
+		if err := localictypes.NewChainsConfig(c).SaveJSON(fmt.Sprintf("%s/chains/standalone.json", cfg.ProjectName)); err != nil {
+			panic(err)
+		}
+
 		// make this is an IBC testnet for POA/POS chains
 		c.SetAppendedIBCPathLink(CosmosHubProvider)
 	}

--- a/spawn/proto_parser_test.go
+++ b/spawn/proto_parser_test.go
@@ -246,6 +246,7 @@ service Msg {
 
 	t.Cleanup(func() {
 		os.RemoveAll(protoDir)
+		os.RemoveAll(path.Join(wd, "x"))
 	})
 }
 


### PR DESCRIPTION
This pull request includes changes to the `spawn/cfg.go` and `spawn/proto_parser_test.go` files to enhance the setup of local interchain configurations and clean up test directories.

Enhancements to local interchain configurations:

* [`spawn/cfg.go`](diffhunk://#diff-ffaf0560b7dcdf35088b0769bec4a744431461333147d3bba8362665a3603429R347-R351): Added logic to save a standalone JSON configuration for testnets with no IBC connections in the `SetupLocalInterchainJSON` function.

Test directory cleanup:

* [`spawn/proto_parser_test.go`](diffhunk://#diff-c82583ea3cad5090cb106da30a24379792898c482d08eb295301f723b336b28bR249): Added cleanup logic to remove the `x` directory after tests are run.