### PR TITLE
refactor: wasm file location path to match expected

### DIFF
--- a/simapp/app/app.go
+++ b/simapp/app/app.go
@@ -810,7 +810,7 @@ func NewChainApp(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
-	wasmDir := filepath.Join(homePath, "wasm")
+	wasmDir := filepath.Join(homePath, "data")
 	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
 	// <spawntag:wasm
 	if err != nil {


### PR DESCRIPTION
mostly all networks are data/wasm vs wasm/wasm due to being pre wasm-lc