### PR TITLE
fix: macos builds not signed, strip debug info on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ endif
 
 DATE := $(shell date '+%Y-%m-%dT%H:%M:%S')
 HEAD = $(shell git rev-parse HEAD)
-LD_FLAGS = -X main.SpawnVersion=$(VERSION)
+# MacOS sequoia + XCode 16 causes the binary to instantly die
+# Stripping the debug info with -s -w fixes this so the binary
+# is properly signed
+# ref: https://github.com/rollchains/spawn/issues/248
+LD_FLAGS = -X main.SpawnVersion=$(VERSION) -s -w
 BUILD_FLAGS = -mod=readonly -ldflags='$(LD_FLAGS)'
 
 ## mod-tidy: go mod tidy spawn, simapp, and interchaintest with proper go.mod suffixes

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ make get-localic
 # Attempt to run a command
 spawn help
 
+# Potential workaround if spawn is immediately killed when attempting run "spawn help" on a m* macbook. 
+# This may happen because of an xcode16 update.
+# To work around this as a temporary measure please change this line in the Make file. 
+LD_FLAGS = -X main.SpawnVersion=$(VERSION)
+# to 
+LD_FLAGS = -X main.SpawnVersion=$(VERSION) -s -w
+
+
 # If you get "command 'spawn' not found", add to path.
 # Run the following in your terminal to test
 # Then add to ~/.bashrc (linux / windows) or ~/.zshrc (mac)

--- a/simapp/Makefile
+++ b/simapp/Makefile
@@ -62,11 +62,14 @@ build_tags_comma_sep := $(subst $(empty),$(comma),$(build_tags))
 
 # process linker flags
 
+# flags '-s -w' resolves an issue with xcode 16 and signing of go binaries
+# ref: https://github.com/golang/go/issues/63997
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=wasm \
 		  -X github.com/cosmos/cosmos-sdk/version.AppName=wasmd \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
+		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
+		  -s -w
 
 ifeq ($(WITH_CLEVELDB),yes)
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=cleveldb


### PR DESCRIPTION
Apple silicon Macbooks with xcode16 may kill the binary immediately after attempting run it , like so. 

```
$ spawn   help
[1]    23969 killed     spawn help
``` 

This update to the readme allows the user to work around the issue. 
This is not being updated as part of the Makefile until more information is known and Xcode might release an update with the fix itself. 