### PR TITLE
chore: Fix version tag sorting in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CWD := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 # don't override user values
 ifeq (,$(VERSION))
-  VERSION := $(shell git tag --sort=taggerdate | tail -1)
+  VERSION := $(shell git tag --sort=version:refname | tail -1)
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
     VERSION := $(BRANCH)-$(COMMIT)


### PR DESCRIPTION
The previous way of sorting tags didn't work; this was the result when I tried locally for me:
```
git tag --sort=taggerdate               
v0.50.0
v0.50.1
v0.50.10
v0.50.2
v0.50.2-alpha.1
v0.50.3
v0.50.4
v0.50.5
v0.50.6
v0.50.7
v0.50.8
v0.50.9
```

This means `make install` would install `v0.50.9`.
Here is the order with the version:refname sorting:

```
git tag --sort=version:refname          
v0.50.0
v0.50.1
v0.50.2
v0.50.2-alpha.1
v0.50.3
v0.50.4
v0.50.5
v0.50.6
v0.50.7
v0.50.8
v0.50.9
v0.50.10
```