### PR TITLE
chore(deps): upload-artifact-action to v4

### DIFF
--- a/simapp/.github/workflows/interchaintest-e2e.yml
+++ b/simapp/.github/workflows/interchaintest-e2e.yml
@@ -63,7 +63,7 @@ jobs:
           outputs: type=docker,dest=${{ env.TAR_PATH }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.IMAGE_NAME }}
           path: ${{ env.TAR_PATH }}

--- a/simapp/.github/workflows/interchaintest-e2e.yml
+++ b/simapp/.github/workflows/interchaintest-e2e.yml
@@ -107,7 +107,7 @@ jobs:
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
       - name: Download Tarball Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.IMAGE_NAME }}
           path: /tmp


### PR DESCRIPTION
Ref: https://github.com/devcoinv0/chain/actions/runs/13178002466

v3 is `deprecated`