### PR TITLE
chore(deps): Bump local-ic to v8.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ get-heighliner:
 
 get-localic:
 	@echo "Installing local-interchain"
-	git clone --depth 1 --branch v8.7.1 https://github.com/strangelove-ventures/interchaintest.git interchaintest-downloader
+	git clone --depth 1 --branch v8.8.1 https://github.com/strangelove-ventures/interchaintest.git interchaintest-downloader
 	cd interchaintest-downloader/local-interchain && make install
 	@sleep 0.1
 	@echo ✅ local-interchain installed $(shell which local-ic)


### PR DESCRIPTION
Resolves the below error on installing spawn.

`ERR New local-ic available current=v8.7.1 latest=v8.8.1 install="git clone https://github.com/strangelove-ventures/interchaintest.git ictd --depth=1 -b v8.8.1 && cd ictd/local-interchain && make install && cd ../.. && rm -rf ictd"`