### PR TITLE
fix: wire erc20 callbacks to EVM

### DIFF
--- a/simapp/app/app.go
+++ b/simapp/app/app.go
@@ -995,6 +995,7 @@ func NewChainApp(
 	// Create Transfer Stack
 	var transferStack porttypes.IBCModule
 	transferStack = transfer.NewIBCModule(app.TransferKeeper)
+	transferStack = erc20.NewIBCMiddleware(app.Erc20Keeper, transferStack) // spawntag:evm
 	transferStack = ratelimit.NewIBCMiddleware(app.RatelimitKeeper, transferStack)
 	transferStack = ibcfee.NewIBCMiddleware(transferStack, app.IBCFeeKeeper)
 	transferStack = packetforward.NewIBCMiddleware(


### PR DESCRIPTION
Adds the ERC20 IBC middleware to the transfer stack under the EVM Spawn tag for automatic ERC20 conversions on token receipts to the chain.